### PR TITLE
Add difficulty to ac alert

### DIFF
--- a/src/atcoder.py
+++ b/src/atcoder.py
@@ -76,7 +76,7 @@ def get_problems_difficulty(problem_list: list) -> dict:
 
     Args:
         problem_list List[str]: difficultyを取得したい問題のidの配列
-            problem_list = abc138_a
+            problem_list = ["abc138_a", "abc_138_d"]
 
     Returns:
         Dict[str, int]: 問題名がkey, difficultyがvalueの連想配列

--- a/src/atcoder.py
+++ b/src/atcoder.py
@@ -1,3 +1,5 @@
+import json
+import math
 from datetime import datetime, timedelta
 from time import sleep
 
@@ -48,13 +50,13 @@ def get_atcoder_contests():
     return contests_info
 
 
-def get_ac_submissions(user):
+def get_ac_submissions(user, sleep_time=1):
     """2h前から現在までのAC提出を取得する"""
     now = int(datetime.now().timestamp())
     tow_hour_ago = now - 7200
     url = f"https://kenkoooo.com/atcoder/atcoder-api/v3/user/submissions?user={user}&from_second={tow_hour_ago}"
     response = requests.get(url)
-    sleep(1)
+    sleep(sleep_time)
     return response.json()
 
 
@@ -65,6 +67,39 @@ def get_members_ac():
         ac = get_ac_submissions(member)
         ac_submissions.append(ac)
     return ac_submissions
+
+
+def get_problems_difficulty(problem_list: list) -> dict:
+    """問題のdifficultyを取得する
+
+    問題のdifficulty一覧を取得するAPIを叩いて特定の問題のdifficultyを返す
+
+    Args:
+        problem_list List[str]: difficultyを取得したい問題のidの配列
+            problem_list = abc138_a
+
+    Returns:
+        Dict[str, int]: 問題名がkey, difficultyがvalueの連想配列
+    """
+    endpoint = "https://kenkoooo.com/atcoder/resources/problem-models.json"
+    response = requests.get(endpoint)
+    all_problems_model = json.loads(response.text)
+    try:
+        target_problems_difficulty = {
+            problem_name: (
+                all_problems_model[problem_name]["difficulty"]
+                if all_problems_model[problem_name]["difficulty"] > 400
+                else round(
+                    400
+                    / math.exp(1 - all_problems_model[problem_name]["difficulty"] / 400)
+                )
+            )
+            for problem_name in problem_list
+        }
+    except KeyError:
+        print(f"error: key was not found")
+    # https://github-wiki-see.page/m/sirogamichandayo/atcoder-diff-problems-go/wiki/diff%E3%81%AE%E3%83%9E%E3%82%A4%E3%83%8A%E3%82%B9%E3%82%92%E7%84%A1%E3%81%8F%E3%81%99%E8%A8%88%E7%AE%97%E5%BC%8F
+    return target_problems_difficulty
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import discord
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -33,6 +34,7 @@ async def ac_alert():
     flat_list = [item for sublist in ac_submissions for item in sublist]
     ac_list = [submission["problem_id"] for submission in flat_list]
     ac_submissions_difficulty = get_problems_difficulty(ac_list)
+    time.sleep(1)
     for submission in ac_submissions:
         msg = ""
         for s in submission:

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from discord import app_commands
 from dotenv import load_dotenv
 
-from atcoder import get_atcoder_contests, get_members_ac
+from atcoder import get_atcoder_contests, get_members_ac, get_problems_difficulty
 from codeforces import get_codeforces_contests
 from triC_member import add_member, get_members
 
@@ -30,11 +30,32 @@ async def send_message(message, channel_id=CHANNEL_ID):
 
 async def ac_alert():
     ac_submissions = get_members_ac()
+    flat_list = [item for sublist in ac_submissions for item in sublist]
+    ac_list = [submission["problem_id"] for submission in flat_list]
+    ac_submissions_difficulty = get_problems_difficulty(ac_list)
     for submission in ac_submissions:
+        msg = ""
         for s in submission:
             if s["result"] == "AC":
-                msg = f"{s['user_id']}が{s['problem_id']}をACしました。\n https://atcoder.jp/contests/{s['contest_id']}/submissions/{s['id']}"
-                await send_message(msg)
+                difficulty = ac_submissions_difficulty[s["problem_id"]]
+                if difficulty < 400:
+                    color = ":hai:"
+                elif difficulty < 800:
+                    color = ":cha:"
+                elif difficulty < 1200:
+                    color = ":midori:"
+                elif difficulty < 1600:
+                    color = ":mizu:"
+                elif difficulty < 2000:
+                    color = ":ao:"
+                elif difficulty < 2400:
+                    color = ":ki:"
+                elif difficulty < 2800:
+                    color = ":daidai:"
+                else:
+                    color = ":aka:"
+                msg += f"{s['user_id']}が{color}{s['problem_id']}をACしました。\n https://atcoder.jp/contests/{s['contest_id']}/submissions/{s['id']}\n"
+        await send_message(msg)
 
 
 async def atcoder_contest():
@@ -87,7 +108,9 @@ async def ping_command(interaction: discord.Interaction):
 @tree.command(name="add_member", description="メンバーを追加します。")
 async def add_member_command(interaction: discord.Interaction, user_id: str):
     add_member(user_id)
-    await interaction.response.send_message(f"{user_id}を追加しました。", ephemeral=False)
+    await interaction.response.send_message(
+        f"{user_id}を追加しました。", ephemeral=False
+    )
 
 
 @tree.command(name="get_members", description="メンバー一覧を取得します。")

--- a/src/test_atcoder.py
+++ b/src/test_atcoder.py
@@ -1,0 +1,19 @@
+import unittest
+
+from atcoder import get_problems_difficulty
+
+
+class TestAtCoder(unittest.TestCase):
+    def test_get_problems_difficulty(self):
+        problem_list = ["abc138_a", "abc138_b", "abc138_c", "abc138_d"]
+        expected_output = {
+            "abc138_a": 18,
+            "abc138_b": 59,
+            "abc138_c": 116,
+            "abc138_d": 920,
+        }
+        self.assertEqual(get_problems_difficulty(problem_list), expected_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test_main.py
+++ b/src/test_main.py
@@ -1,0 +1,73 @@
+import unittest
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import MagicMock, call, patch
+
+from main import ac_alert
+
+
+class TestMain(IsolatedAsyncioTestCase):
+    @patch("main.client.run", new_callable=MagicMock)
+    @patch("main.get_members_ac")
+    @patch("main.get_problems_difficulty")
+    @patch("main.send_message")
+    async def test_ac_alert(
+        self,
+        mock_send_message,
+        mock_get_problems_difficulty,
+        mock_get_members_ac,
+        mock_client_run,
+    ):
+        # Mock data
+        ac_submissions = [
+            [
+                {
+                    "user_id": "user1",
+                    "problem_id": "abc138_a",
+                    "result": "AC",
+                    "id": "12345",
+                    "contest_id": "abc138",
+                }
+            ],
+            [
+                {
+                    "user_id": "user2",
+                    "problem_id": "abc138_a",
+                    "result": "AC",
+                    "id": "12345",
+                    "contest_id": "abc138",
+                },
+                {
+                    "user_id": "user2",
+                    "problem_id": "abc138_d",
+                    "result": "AC",
+                    "id": "67890",
+                    "contest_id": "abc138",
+                },
+            ],
+        ]
+        ac_submissions_difficulty = {"abc138_a": 18, "abc138_d": 920}
+
+        # Mock function return values
+        mock_get_members_ac.return_value = ac_submissions
+        mock_get_problems_difficulty.return_value = ac_submissions_difficulty
+
+        # Call the function
+        await ac_alert()
+
+        expected_calls = [
+            call(
+                "user1が:hai:abc138_aをACしました。\n https://atcoder.jp/contests/abc138/submissions/12345\n"
+            ),
+            call(
+                "user2が:hai:abc138_aをACしました。\n https://atcoder.jp/contests/abc138/submissions/12345\nuser2が:midori:abc138_dをACしました。\n https://atcoder.jp/contests/abc138/submissions/67890\n"
+            ),
+        ]
+
+        # Assert the function calls
+        mock_get_members_ac.assert_called_once()
+        mock_get_problems_difficulty.assert_called_once()
+        mock_send_message.assert_has_calls(expected_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 変更点
- ACした問題のdifficultyをAC ALERTに追加
  - discordの絵文字を使用して色を表現
  - AtCoder ProblemsのAPI[問題の難易度の目安](https://github.com/kenkoooo/AtCoderProblems/blob/master/doc/api.md)からdifficutlyを取得
- 通知数が増えることの対策として一人につき1つのメッセージにまとめるように変更
- 当該の機能のテストを追加
- sleepの秒数をdefault引数に指定