### PR TITLE
AtCoderのAC通知でカウントがおかしくなっているのを修正

### DIFF
--- a/src/atcoder.py
+++ b/src/atcoder.py
@@ -79,23 +79,26 @@ def get_problems_difficulty(problem_list: list) -> dict:
             problem_list = ["abc138_a", "abc_138_d"]
 
     Returns:
-        Dict[str, int]: 問題名がkey, difficultyがvalueの連想配列
+        Dict[str, int]: 問題名がkey, difficultyがvalueの連想配列 (difficultyが得られない場合はNone)
     """
     endpoint = "https://kenkoooo.com/atcoder/resources/problem-models.json"
     response = requests.get(endpoint)
     all_problems_model = json.loads(response.text)
+
+    target_problems_difficulty = dict()
+
     try:
-        target_problems_difficulty = {
-            problem_name: (
-                all_problems_model[problem_name]["difficulty"]
-                if all_problems_model[problem_name]["difficulty"] > 400
-                else round(
-                    400
-                    / math.exp(1 - all_problems_model[problem_name]["difficulty"] / 400)
-                )
-            )
-            for problem_name in problem_list
-        }
+        for problem_name in problem_list:
+            if problem_name in all_problems_model and "difficulty" in all_problems_model[problem_name]:
+                diff = all_problems_model[problem_name]["difficulty"]
+                if diff <= 400:
+                    diff = round(400 / math.exp(1 - diff / 400))
+            
+                target_problems_difficulty[problem_name] = diff 
+
+            else:
+                target_problems_difficulty[problem_name] = None
+                
         return target_problems_difficulty
     except KeyError:
         print(f"error: key was not found")

--- a/src/main.py
+++ b/src/main.py
@@ -33,7 +33,8 @@ async def send_message(message, channel_id=CHANNEL_ID):
     else:
         print(f"Channel with ID {channel_id} not found.")
 
-async def send_embedded_message(title, url, description, color=0xffffff,channel_id=CHANNEL_ID):
+
+async def send_embedded_message(title, url, description, color=0xffffff, channel_id=CHANNEL_ID):
     """指定したチャンネルIDに埋め込みメッセージをembeddedで送信する関数"""
     channel = client.get_channel(int(channel_id))
     if channel:
@@ -51,13 +52,16 @@ async def ac_alert():
     flat_list = [item for sublist in ac_submissions for item in sublist]
     ac_list = [submission["problem_id"] for submission in flat_list]
     ac_submissions_difficulty = get_problems_difficulty(ac_list)
+    ac_count = 0
+
     time.sleep(1)
     for submission in ac_submissions:
         msg = ""
         for s in submission:
             if s["result"] == "AC":
-                if s["problem_id"] in ac_submissions_difficulty:
+                if s["problem_id"] in ac_submissions_difficulty and ac_submissions_difficulty[s["problem_id"]] is not None:
                     difficulty = ac_submissions_difficulty[s["problem_id"]]
+
                     if difficulty < 400:
                         color = "<:hai:1225032949964083251>"
                     elif difficulty < 800:
@@ -77,9 +81,10 @@ async def ac_alert():
                 else:
                     color = ""
                 msg += f"{s['problem_id']}{color} https://atcoder.jp/contests/{s['contest_id']}/submissions/{s['id']}\n"
+                ac_count += 1
         if msg:
             await send_embedded_message(
-                title=f"{s['user_id']}が{len(submission)}問<:accepted:1110414595316781147>しました",
+                title=f"{s['user_id']}が{ac_count}問<:accepted:1110414595316781147>しました",
                 url="",
                 description=msg,
                 color=0x5cb85c

--- a/src/test_atcoder.py
+++ b/src/test_atcoder.py
@@ -5,12 +5,13 @@ from atcoder import get_problems_difficulty
 
 class TestAtCoder(unittest.TestCase):
     def test_get_problems_difficulty(self):
-        problem_list = ["abc138_a", "abc138_b", "abc138_c", "abc138_d"]
+        problem_list = ["abc138_a", "abc138_b", "abc138_c", "abc138_d", "pakencamp_2018_day2_a"]
         expected_output = {
             "abc138_a": 18,
             "abc138_b": 59,
             "abc138_c": 116,
             "abc138_d": 920,
+            "pakencamp_2018_day2_a": None
         }
         self.assertEqual(get_problems_difficulty(problem_list), expected_output)
 


### PR DESCRIPTION
- AtCoderのAC通知でDifficultyがない問題に対応するように実装
- AC数のカウントを、実際にACしたSubmissionの数でカウントするように変更
- Difficultyがない問題のテストケースをtest_atcoder.pyに追加


(書いていて思ったんですが、こういう3つの変更って複数コミットに分けるべきだったりしますか？)